### PR TITLE
Get all the recorded values in the selected time range, without interpolation

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -83,6 +83,7 @@ export class PiWebApiDatasource {
         refId: target.refId,
         hide: target.hide,
         interpolate: target.interpolate || {enable: false},
+        recordedValues: target.recordedValues || {enable: false},
         webid: target.webid,
         webids: target.webids || [],
         regex: target.regex || {enable: false},
@@ -90,7 +91,10 @@ export class PiWebApiDatasource {
         summary: target.summary || {types: []}
         // items: results
       }
-
+      
+      if (tar.expression) {
+        tar.expression = this.templateSrv.replace(tar.expression);
+      }
 
       if (tar.summary.types !== undefined) {
         tar.summary.types = _.filter(tar.summary.types, item => { return item !== undefined && item !== null && item !== '' })
@@ -462,6 +466,8 @@ export class PiWebApiDatasource {
           url += '/summary' + timeRange + '&intervals=' + query.maxDataPoints + this.getSummaryUrl(target.summary)
         } else if (target.interpolate && target.interpolate.enable) {
           url += '/interpolated' + timeRange + '&interval=' + intervalTime
+        } else if (target.recordedValues && target.recordedValues.enable) {
+          url += '/recorded' + timeRange + '&maxCount=' + target.recordedValues.maxNumber
         } else {
           url += '/plot' + timeRange + '&intervals=' + query.maxDataPoints
         }

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -45,6 +45,20 @@
 
 	<div class="gf-form-inline">
 		<div class="gf-form">
+			<label class="gf-form-label query-keyword width-11">Max Recorded Values
+					<i class="fa fa-question-circle" bs-tooltip="'Maximum number of recorded value to retrive from the data archive, without using interpolation.'" data-placement="top"></i>
+				</label>
+			<input type="number" class="gf-form-input width-6" ng-model="ctrl.target.recordedValues.maxNumber" placeholder="150000"
+				ng-blur="ctrl.refresh()"></input>
+		</div>
+		<div class="gf-form">
+			<gf-form-switch class="gf-form-inline" label="Recorded Values" label-class="query-keyword" checked="ctrl.target.recordedValues.enable"
+				on-change="ctrl.targetBlur()" ng-disabled="ctrl.target.interpolate.enable">
+			</gf-form-switch>
+		</div>
+  </div>
+	<div class="gf-form-inline">
+		<div class="gf-form">
 			<label class="gf-form-label query-keyword width-11">Interpolate Period
 					<i class="fa fa-question-circle" bs-tooltip="'Override time between sampling, e.g. \'30s\'. Defaults to timespan/chart width.'" data-placement="top"></i>
 				</label>
@@ -53,7 +67,7 @@
 		</div>
 		<div class="gf-form">
 			<gf-form-switch class="gf-form-inline" label="Interpolate" label-class="query-keyword" checked="ctrl.target.interpolate.enable"
-				on-change="ctrl.targetBlur()">
+				on-change="ctrl.targetBlur()" ng-disabled="ctrl.target.recordedValues.enable">
 			</gf-form-switch>
 		</div>
     <div class="gf-form">

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -66,7 +66,13 @@ export class PiWebApiDatasourceQueryCtrl extends QueryCtrl {
       this.target.interpolate = { enable: this.target.interpolate }
     }
     this.target.interpolate.enable = this.target.interpolate.enable || false
-
+    
+    this.target.recordedValues = this.target.recordedValues || {enable: false}
+    if (this.target.recordedValues === false || this.target.recordedValues === true) {
+      this.target.recordedValues = { enable: this.target.recordedValues }
+    }
+    this.target.recordedValues.enable = this.target.recordedValues.enable || false
+    
     if (this.segments.length === 0) {
       this.segments.push(this.uiSegmentSrv.newSelectMetric())
     }


### PR DESCRIPTION
This allows the extraction of the recorded value available in the selected time range, without using interpolation.

It use the GetRecorded PI WEB API function and allow the configuration of the maxCount parameter.

This fix the issue of the same name (#13 )