### PR TITLE
Fix for metricFindQuery isPiPoint not boolean

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -316,7 +316,7 @@ export class PiWebApiDatasource {
     } else if (query.type !== 'attributes') {
       query.type = querydepth[Math.max(0, Math.min(query.path.split('\\').length, querydepth.length - 1))]
     }
-    if (isPiPoint) {
+    if (isPiPoint === true) {
       query.type = 'dataserver'
       
       if (query.webId !== undefined && query.webId !== '') {


### PR DESCRIPTION
Dashboard variable dropdowns were not working correctly.  isPointPoint could be an object of query options, so using === true instead.