### PR TITLE
fix the path to the data source logo

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -14,8 +14,8 @@
     },
     "keywords": ["OSIsoft", "PI", "Historian", "GPA"],
     "logos": {
-      "small": "img/logo.svg",
-      "large": "img/logo.svg"
+      "small": "img/osi-pi.png",
+      "large": "img/osi-pi.png"
     },
     "links": [
       {


### PR DESCRIPTION
Hi, 
while testing version 4.2.0 i've noticed that logo icon of data source is not available.
The PR should fix it
<img width="458" alt="Screenshot 2023-06-13 at 14 02 39" src="https://github.com/GridProtectionAlliance/osisoftpi-grafana/assets/6554653/bd1f0f42-8abc-400a-a1c6-bb2dcceb5c46">
