### PR TITLE
Fix SummaryType unmarshal to handle bare string format

### DIFF
--- a/pkg/plugin/timeseries_query_models.go
+++ b/pkg/plugin/timeseries_query_models.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -162,6 +163,30 @@ type QueryProperties struct {
 type SummaryType struct {
 	Label string           `json:"label"`
 	Value SummaryTypeValue `json:"value"`
+}
+
+// UnmarshalJSON handles two formats that appear in the wild:
+//   - Object: {"label":"Total","value":{"value":"Total","expandable":true}}  (normal)
+//   - String: "Total" or ""  (legacy saved queries / alert rules)
+//
+// Empty strings are treated as a no-op by returning a zero-value struct; callers
+// should filter out entries where Value.Value == "".
+func (s *SummaryType) UnmarshalJSON(data []byte) error {
+	// Try object form first
+	type summaryTypeAlias SummaryType
+	var obj summaryTypeAlias
+	if err := json.Unmarshal(data, &obj); err == nil {
+		*s = SummaryType(obj)
+		return nil
+	}
+	// Fall back to plain string form
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	s.Label = str
+	s.Value = SummaryTypeValue{Value: str, Expandable: true}
+	return nil
 }
 
 type SummaryTypeValue struct {


### PR DESCRIPTION
Alert rules and saved queries send summary types as bare strings (e.g. "Total" or "") rather than the expected object form. The standard JSON unmarshaller fails with 'cannot unmarshal string into Go struct field'.

Add a custom UnmarshalJSON on SummaryType that accepts both formats:
- Object: {"label":"...","value":{"value":"...","expandable":true}}
- String: "Total" or "" (legacy / alert rule format)

Empty strings unmarshal to a zero-value struct. getSummaryURIComponent is updated to skip zero-value entries so they don't produce a dangling &summaryType= in the PI Web API URL.

Fixes the 'Process query - Error unmarshalling' error seen when alert rules fire against queries with summary.types:[""].